### PR TITLE
ci: switch from BuildJet to standard GitHub Actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,10 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Install Go
-        uses: buildjet/setup-go@v5
+        uses: actions/setup-go@v5
         with:
           go-version: v1.23.x
-      - uses: buildjet/cache@v4
+      - uses: actions/cache@v4
         with:
           path: |
             ~/go/pkg/mod
@@ -49,6 +49,10 @@ jobs:
     needs: semantic-release
     runs-on: ubuntu-latest
     steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
       - name: Set up QEMU


### PR DESCRIPTION
- Replace buildjet/setup-go with actions/setup-go
- Replace buildjet/cache with actions/cache
- Add disk space cleanup for docker multi-arch builds